### PR TITLE
Allow relaunching when offline

### DIFF
--- a/src/main/java/com/cleanroommc/relauncher/CleanroomRelauncher.java
+++ b/src/main/java/com/cleanroommc/relauncher/CleanroomRelauncher.java
@@ -14,9 +14,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.lang.management.ManagementFactory;
 import java.nio.file.*;
 import java.util.*;
@@ -66,8 +64,22 @@ public class CleanroomRelauncher {
         try {
             releases = CleanroomRelease.queryAll();
             latestRelease = releases.get(0);
+
+            // After retrieving releases, save them to releases.json
+            saveReleasesToCache(CACHE_DIR.resolve("releases.json"), releases);
+            LOGGER.info("Saved {} releases to cache.", releases.size());
+
         } catch (IOException e) {
-            throw new RuntimeException("Unable to query Cleanroom's releases.", e);
+            if (Files.exists(CACHE_DIR.resolve("releases.json"))) {
+
+                LOGGER.info("Loading releases from cached releases.json");
+
+                // Load releases from local cache if internet isn't available
+                releases = loadReleasesFromCache(CACHE_DIR.resolve("releases.json"));
+                latestRelease = releases.get(0); // Assume at least one release is available
+            } else {
+                throw new RuntimeException("Unable to query Cleanroom's releases and no cached releases found.", e);
+            }
         }
 
         LOGGER.info("{} cleanroom releases were queried.", releases.size());
@@ -79,7 +91,7 @@ public class CleanroomRelauncher {
         String javaArgs = CONFIG.getJavaArguments();
         boolean needsNotifyLatest = notedLatestVersion == null || !notedLatestVersion.equals(latestRelease.name);
         if (selectedVersion != null) {
-            selected = releases.stream().filter(cr -> cr.name.equals(selectedVersion)).findFirst().get();
+            selected = releases.stream().filter(cr -> cr.name.equals(selectedVersion)).findFirst().orElse(null);
         }
         if (javaPath != null && !new File(javaPath).isFile()) {
             javaPath = null;
@@ -152,8 +164,18 @@ public class CleanroomRelauncher {
         arguments.add(javaPath);
 
         arguments.add("-cp");
-        // arguments.add(String.join(File.pathSeparator, buildClassPath(releaseCache)) + ";" + getOriginalClassPath());
-        arguments.add(wrapperClassPath + File.pathSeparator + versions.stream().map(version -> version.libraryPaths).flatMap(Collection::stream).collect(Collectors.joining(File.pathSeparator)));
+        String libraryClassPath = versions.stream()
+                .map(version -> version.libraryPaths)
+                .flatMap(Collection::stream)
+                .collect(Collectors.joining(File.pathSeparator));
+
+        // Check if libraryClassPath is empty and log it for debugging
+        if (libraryClassPath.isEmpty()) {
+            LOGGER.warn("No libraries found in the classpath. Ensure that libraries are being downloaded.");
+        }
+
+        String fullClassPath = wrapperClassPath + File.pathSeparator + libraryClassPath;
+        arguments.add(fullClassPath); // Ensure this is not empty
 
         for (String argument : ManagementFactory.getRuntimeMXBean().getInputArguments()) {
             if (!argument.startsWith("-Djava.library.path")) {
@@ -195,4 +217,36 @@ public class CleanroomRelauncher {
         }
     }
 
+    /**
+     * Loads the cached {@link CleanroomRelease}'s from the specified file.
+     *
+     * @param releaseFile the path to the file containing cached release data.
+     * @return a list of {@link CleanroomRelease} objects loaded from the cache file.
+     *
+     * @throws RuntimeException if an {@link IOException} occurs while reading the file
+     *         or if the content cannot be properly deserialized into the list of releases.
+     */
+    private static List<CleanroomRelease> loadReleasesFromCache(Path releaseFile) {
+        try (Reader reader = Files.newBufferedReader(releaseFile)) {
+            return Arrays.asList(GSON.fromJson(reader, CleanroomRelease[].class));
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to load cached releases.", e);
+        }
+    }
+
+    /**
+     * Saves the list of releases to the specified cache file.
+     *
+     * @param releaseFile the path to the file where the releases should be saved.
+     * @param releases the list of {@link CleanroomRelease}'s to be saved.
+     *
+     * @throws RuntimeException if an {@link IOException} occurs while writing to the file.
+     */
+    private static void saveReleasesToCache(Path releaseFile, List<CleanroomRelease> releases) {
+        try (Writer writer = Files.newBufferedWriter(releaseFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            GSON.toJson(releases, writer);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to save releases to cache.", e);
+        }
+    }
 }

--- a/src/main/java/com/cleanroommc/relauncher/download/CleanroomRelease.java
+++ b/src/main/java/com/cleanroommc/relauncher/download/CleanroomRelease.java
@@ -6,13 +6,37 @@ import com.google.gson.reflect.TypeToken;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.Writer;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.List;
 
 public class CleanroomRelease {
 
+    private static final Path CACHE_FILE = CleanroomRelauncher.CACHE_DIR.resolve("releases.json");
+
     public static List<CleanroomRelease> queryAll() throws IOException {
+        // Check if the cache file exists and is not outdated
+        if (Files.exists(CACHE_FILE)) {
+            CleanroomRelauncher.LOGGER.info("Loading releases from cached releases.json");
+            return fetchReleasesFromCache(CACHE_FILE);
+        } else {
+            CleanroomRelauncher.LOGGER.info("No cache found, fetching releases...");
+            List<CleanroomRelease> releases = fetchReleasesFromGithub();
+
+            // After fetching releases, save them to the cache
+            saveReleasesToCache(CACHE_FILE, releases);
+
+            return releases;
+        }
+    }
+
+    private static List<CleanroomRelease> fetchReleasesFromGithub() throws IOException {
         try {
             URL url = new URL("https://api.github.com/repos/CleanroomMC/Cleanroom/releases");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
@@ -28,6 +52,40 @@ public class CleanroomRelease {
             }
         } catch (Exception e) {
             throw new IOException("Failed to fetch or parse releases", e);
+        }
+    }
+
+    /**
+     * Loads the cached {@link CleanroomRelease}'s from the specified file.
+     *
+     * @param releaseFile the path to the file containing cached release data.
+     * @return a list of {@link CleanroomRelease} objects loaded from the cache file.
+     *
+     * @throws RuntimeException if an {@link IOException} occurs while reading the file
+     *         or if the content cannot be properly deserialized into the list of releases.
+     */
+    private static List<CleanroomRelease> fetchReleasesFromCache(Path releaseFile) {
+        try (Reader reader = Files.newBufferedReader(releaseFile)) {
+            return Arrays.asList(CleanroomRelauncher.GSON.fromJson(reader, CleanroomRelease[].class));
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to load cached releases.", e);
+        }
+    }
+
+    /**
+     * Saves the list of releases to the specified cache file.
+     *
+     * @param releaseFile the path to the file where the releases should be saved.
+     * @param releases the list of {@link CleanroomRelease}'s to be saved.
+     *
+     * @throws RuntimeException if an {@link IOException} occurs while writing to the file.
+     */
+    private static void saveReleasesToCache(Path releaseFile, List<CleanroomRelease> releases) {
+        try (Writer writer = Files.newBufferedWriter(releaseFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            CleanroomRelauncher.GSON.toJson(releases, writer);
+            CleanroomRelauncher.LOGGER.info("Saved {} releases to cache.", releases.size());
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to save releases to cache.", e);
         }
     }
 


### PR DESCRIPTION
Saves the possible releases to a releases.json file when relaunching online, then when you don't have an internet connection (Or something else causes CleanroomRelease.queryAll() to throw its IOException), use that file. 

Requires you to have relaunched at least once, but you need to anyway to get dependencies and such. 

![image](https://github.com/user-attachments/assets/0a69bc24-aa70-49c9-bb8d-fe00fb8279e0)
