### PR TITLE
Have Relauncher load sooner to prevent crashes and speed up loading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ version = propertyString('mod_version')
 group = propertyString('root_package')
 
 base {
-    archivesName.set(propertyString('mod_id'))
+    archivesName.set('!' + propertyString('mod_id'))
 }
 
 tasks.decompressDecompiledSources.enabled !propertyBool('change_minecraft_sources')


### PR DESCRIPTION
This pr adds an exclamation mark in front the the jar name so Relauncher is loaded sooner.

This has two benefits:
- Prevent crashes where a mod requiring mixins is loaded on Forge without mixinbooter, before Cleanroom Loader can provide one
- Stop the game from loading a couple of mods before it is relaunched, because that loading is discarded anyway
  -  As an example, my instance loads redcore, alfheim, asset mover, astikorcarts, and censored asm before loading relauncher