### PR TITLE
Replace `Method` with `MethodHandle` for cleaner stacktrace

### DIFF
--- a/mainWrapper/src/main/java/com/cleanroommc/relauncher/wrapper/RelaunchMainWrapper.java
+++ b/mainWrapper/src/main/java/com/cleanroommc/relauncher/wrapper/RelaunchMainWrapper.java
@@ -1,5 +1,8 @@
 package com.cleanroommc.relauncher.wrapper;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
 public class RelaunchMainWrapper {
     public static void main(String[] args) throws Throwable {
         String mainClassName = System.getProperty("cleanroom.relauncher.mainClass");
@@ -12,7 +15,9 @@ public class RelaunchMainWrapper {
         // Parent watcher (Java 9+)
         parentProcess.onExit().thenRun(() -> System.exit(0));
 
-        Class.forName(mainClassName).getMethod("main", String[].class).invoke(null, (Object) args);
+        MethodHandles.lookup()
+            .findStatic(Class.forName(mainClassName), "main", MethodType.methodType(void.class, String[].class))
+            .invoke((Object) args);
     }
 
 }


### PR DESCRIPTION
This PR, combined with https://github.com/kappa-maintainer/Foundation/pull/7 and https://github.com/kappa-maintainer/Foundation/pull/8 , can greatly reduce noises in stacktrace:

```diff
java.util.concurrent.ExecutionException: java.lang.IndexOutOfBoundsException: Index 16 out of bounds for length 0
    at java.util.concurrent.FutureTask.report(FutureTask.java:122)
    at java.util.concurrent.FutureTask.get(FutureTask.java:191)
    at net.minecraft.util.Util.runTask(SourceFile:531)
    at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1068)
    at net.minecraft.client.Minecraft.run(Unknown Source)
    at net.minecraft.client.main.Main.main(SourceFile:123)
-   at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
-   at java.lang.reflect.Method.invoke(Method.java:580)
    at top.outlands.foundation.LaunchHandler.launch(LaunchHandler.java:121)
-   at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
-   at java.lang.reflect.Method.invoke(Method.java:580)
    at top.outlands.foundation.boot.Foundation.main(Foundation.java:41)
-   at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
-   at java.lang.reflect.Method.invoke(Method.java:580)
    at com.cleanroommc.relauncher.wrapper.RelaunchMainWrapper.main(RelaunchMainWrapper.java:15)
```