### PR TITLE
Add `-XX:+UseCompactObjectHeaders` to default java arguments in confg

### DIFF
--- a/src/main/java/com/cleanroommc/relauncher/config/RelauncherConfiguration.java
+++ b/src/main/java/com/cleanroommc/relauncher/config/RelauncherConfiguration.java
@@ -33,7 +33,7 @@ public class RelauncherConfiguration {
     @SerializedName("javaPath")
     private String javaExecutablePath;
     @SerializedName("args")
-    private String javaArguments = "";
+    private String javaArguments = "-XX:+UseCompactObjectHeaders";
 
     public String getCleanroomVersion() {
         return cleanroomVersion;


### PR DESCRIPTION
There is no downside to it as opposed to `-XX:+UseZGC`. Just an idea: maybe we can put checkboxes for them in the Swing GUI?