### PR TITLE
Fix Update notifications leaking

### DIFF
--- a/src/main/java/com/cleanroommc/relauncher/CleanroomRelauncher.java
+++ b/src/main/java/com/cleanroommc/relauncher/CleanroomRelauncher.java
@@ -161,7 +161,7 @@ public class CleanroomRelauncher {
             $.javaArgs        = javaArgs;
             $.autoSetup       = autoSetup;
             $.shouldScale     = isJvm8;
-            $.updateNotification = updateNotification;
+            $.updateNotification = CONFIG.getFetchUpdatesEnabled() && updateNotification;
         });
     }
     public static void clearFolders() {


### PR DESCRIPTION
For some reasons, there's been some rogue cases where notifications GUI kept showing up despite fetchUpdates disabled.
This should fix it.