### PR TITLE
Fix relauncher GUI on certain Linux compositors

### DIFF
--- a/src/main/java/com/cleanroommc/relauncher/gui/ConfigGUI.java
+++ b/src/main/java/com/cleanroommc/relauncher/gui/ConfigGUI.java
@@ -93,7 +93,7 @@ public class ConfigGUI extends RelauncherFrame {
 
         JButton configSaveButton = new JButton("Save Settings");
         RelauncherUI.primary(configSaveButton);
-        configSaveButton.setToolTipText("Save and apply on next launch (Enter)");
+        RelauncherUI.tooltip(configSaveButton, "Save and apply on next launch (Enter)");
         this.getRootPane().setDefaultButton(configSaveButton);
         configSaveButton.addActionListener(e -> {
             if (selected == null) {
@@ -125,7 +125,7 @@ public class ConfigGUI extends RelauncherFrame {
 
         JButton configCancelButton = new JButton("Discard Changes");
         RelauncherUI.ghost(configCancelButton);
-        configCancelButton.setToolTipText("Close without saving (Esc)");
+        RelauncherUI.tooltip(configCancelButton, "Close without saving (Esc)");
         configCancelButton.addActionListener(e -> discardAndClose());
 
         configButtonPanel.add(configCancelButton);

--- a/src/main/java/com/cleanroommc/relauncher/gui/LoadingGUI.java
+++ b/src/main/java/com/cleanroommc/relauncher/gui/LoadingGUI.java
@@ -187,7 +187,7 @@ public class LoadingGUI {
     public void updateStatus(String status) {
         SwingUtilities.invokeLater(() -> {
             statusLabel.setText(status);
-            statusLabel.setToolTipText(status);
+            RelauncherUI.tooltip(statusLabel, status);
         });
     }
 

--- a/src/main/java/com/cleanroommc/relauncher/gui/LoadingGUI.java
+++ b/src/main/java/com/cleanroommc/relauncher/gui/LoadingGUI.java
@@ -26,6 +26,7 @@ public class LoadingGUI {
 
         frame = new JFrame("Cleanroom Relauncher");
         frame.setUndecorated(true);
+        frame.setResizable(false);
         frame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
         frame.setSize(Math.round(WINDOW_WIDTH * scale), Math.round(WINDOW_HEIGHT * scale));
         frame.setLayout(new BorderLayout());

--- a/src/main/java/com/cleanroommc/relauncher/gui/RelauncherFrame.java
+++ b/src/main/java/com/cleanroommc/relauncher/gui/RelauncherFrame.java
@@ -65,6 +65,7 @@ public abstract class RelauncherFrame extends JFrame {
         this.windowIcon = icon;
         this.setIconImage(icon);
         this.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        this.setResizable(false);
         this.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {

--- a/src/main/java/com/cleanroommc/relauncher/gui/RelauncherFrame.java
+++ b/src/main/java/com/cleanroommc/relauncher/gui/RelauncherFrame.java
@@ -15,8 +15,6 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import java.awt.*;
 import java.awt.event.ItemEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
@@ -350,8 +348,8 @@ public abstract class RelauncherFrame extends JFrame {
 
         JButton autoDetect = new JButton("Find Installed Java");
         JButton test = new JButton("Test Java");
-        autoDetect.setToolTipText("Scan common install locations for Java " + MINIMUM_JAVA + "+");
-        test.setToolTipText("Verify the selected executable to be compatible with Cleanroom");
+        RelauncherUI.tooltip(autoDetect, "Scan common install locations for Java " + MINIMUM_JAVA + "+");
+        RelauncherUI.tooltip(test, "Verify the selected executable to be compatible with Cleanroom");
         options.add(autoDetect);
         options.add(test);
 
@@ -478,7 +476,7 @@ public abstract class RelauncherFrame extends JFrame {
         JTextField text = new JTextField(40);
         // Same UI face as the rest of the app
         text.setText(javaArgs);
-        text.setToolTipText("JVM flags passed to Cleanroom, e.g. -Xmx4G");
+        RelauncherUI.tooltip(text, "JVM flags passed to Cleanroom, e.g. -Xmx4G");
         text.setAlignmentX(Component.LEFT_ALIGNMENT);
         listenToTextFieldUpdate(text, t -> javaArgs = t.getText());
         RelauncherUI.installTextFieldFocus(text);
@@ -511,7 +509,7 @@ public abstract class RelauncherFrame extends JFrame {
                 continue; // Implicit, driven by the target Java version rather than by the user
             }
             JCheckBox checkBox = new JCheckBox(RelauncherUI.argumentLabel(arg));
-            checkBox.setToolTipText(RelauncherUI.argumentTooltip(arg));
+            RelauncherUI.tooltip(checkBox, RelauncherUI.argumentTooltip(arg));
 
             boolean preselected = javaArgsSupplied ? argumentPresent(javaArgs, arg) : arg.isSelectedByDefault();
             checkBox.setSelected(preselected);

--- a/src/main/java/com/cleanroommc/relauncher/gui/RelauncherFrame.java
+++ b/src/main/java/com/cleanroommc/relauncher/gui/RelauncherFrame.java
@@ -57,8 +57,8 @@ public abstract class RelauncherFrame extends JFrame {
     public JavaDistro vendorSelected;
     public String javaPath, javaArgs;
 
-    protected JComboBox<CleanroomRelease> cleanroomReleaseBox;
-    protected RelauncherUI.SegmentedControl javaModeControl;
+    JComboBox<CleanroomRelease> cleanroomReleaseBox;
+    RelauncherUI.SegmentedControl javaModeControl;
 
     protected RelauncherFrame(String title, Image icon) {
         super(title);

--- a/src/main/java/com/cleanroommc/relauncher/gui/RelauncherFrame.java
+++ b/src/main/java/com/cleanroommc/relauncher/gui/RelauncherFrame.java
@@ -66,12 +66,6 @@ public abstract class RelauncherFrame extends JFrame {
         this.setIconImage(icon);
         this.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         this.setResizable(false);
-        this.addMouseListener(new MouseAdapter() {
-            @Override
-            public void mouseClicked(MouseEvent e) {
-                RelauncherFrame.this.requestFocusInWindow();
-            }
-        });
     }
 
     /** Hint shown after the user picks an executable, e.g. "Test it before saving." */

--- a/src/main/java/com/cleanroommc/relauncher/gui/RelauncherGUI.java
+++ b/src/main/java/com/cleanroommc/relauncher/gui/RelauncherGUI.java
@@ -161,7 +161,7 @@ public class RelauncherGUI extends RelauncherFrame {
 
         JButton fastRelaunchBtn = new JButton("Relaunch Now");
         RelauncherUI.primary(fastRelaunchBtn);
-        fastRelaunchBtn.setToolTipText("Install the latest Cleanroom with automatic Java setup (Enter)");
+        RelauncherUI.tooltip(fastRelaunchBtn, "Install the latest Cleanroom with automatic Java setup (Enter)");
         fastRelaunchBtn.addActionListener(e -> {
             autoSetup = true;
             // Match the card: latest release + automatic Java, not leftover Advanced selections.
@@ -170,7 +170,7 @@ public class RelauncherGUI extends RelauncherFrame {
         });
         JButton advancedBtn = new JButton("Advanced Settings");
         RelauncherUI.ghost(advancedBtn);
-        advancedBtn.setToolTipText("Choose Cleanroom version, Java runtime, and JVM flags");
+        RelauncherUI.tooltip(advancedBtn, "Choose Cleanroom version, Java runtime, and JVM flags");
         advancedBtn.addActionListener(e -> showAdvancedScreen());
 
         fastRelaunchBtn.setAlignmentX(Component.CENTER_ALIGNMENT);
@@ -233,7 +233,7 @@ public class RelauncherGUI extends RelauncherFrame {
         JButton fastUpdateBtn = new JButton("Update Now");
         RelauncherUI.primary(fastUpdateBtn);
         RelauncherUI.sizeActionButton(fastUpdateBtn, 160, 40);
-        fastUpdateBtn.setToolTipText("Install " + latestName + " and relaunch");
+        RelauncherUI.tooltip(fastUpdateBtn, "Install " + latestName + " and relaunch");
         fastUpdateBtn.addActionListener(e -> {
             autoSetup = true;
             selected = null;
@@ -242,7 +242,7 @@ public class RelauncherGUI extends RelauncherFrame {
 
         JButton skipBtn = new JButton("Keep Current");
         RelauncherUI.sizeActionButton(skipBtn, 150, 40);
-        skipBtn.setToolTipText("Stay on " + currentName + " for now");
+        RelauncherUI.tooltip(skipBtn, "Stay on " + currentName + " for now");
         skipBtn.addActionListener(e -> {
             autoSetup = true;
             dispose();
@@ -251,7 +251,7 @@ public class RelauncherGUI extends RelauncherFrame {
         JButton advancedBtn = new JButton("Advanced Settings");
         RelauncherUI.ghost(advancedBtn);
         RelauncherUI.sizeActionButton(advancedBtn, 200, 38);
-        advancedBtn.setToolTipText("Review version, Java, and JVM flags before updating");
+        RelauncherUI.tooltip(advancedBtn, "Review version, Java, and JVM flags before updating");
         advancedBtn.addActionListener(e -> showAdvancedScreen());
 
         startDefaultButton = fastUpdateBtn;
@@ -309,12 +309,12 @@ public class RelauncherGUI extends RelauncherFrame {
         JPanel relaunchButtonPanel = RelauncherUI.footer();
 
         JButton backButton = new JButton("Back");
-        backButton.setToolTipText("Return to the previous screen (Esc)");
+        RelauncherUI.tooltip(backButton, "Return to the previous screen (Esc)");
         backButton.addActionListener(e -> showStartScreen());
 
         JButton relaunchButton = new JButton("Relaunch with Cleanroom");
         RelauncherUI.primary(relaunchButton);
-        relaunchButton.setToolTipText("Validate settings and relaunch (Enter)");
+        RelauncherUI.tooltip(relaunchButton, "Validate settings and relaunch (Enter)");
         advancedDefaultButton = relaunchButton;
         relaunchButton.addActionListener(e -> {
             if (selected == null) {

--- a/src/main/java/com/cleanroommc/relauncher/gui/RelauncherUI.java
+++ b/src/main/java/com/cleanroommc/relauncher/gui/RelauncherUI.java
@@ -1024,6 +1024,22 @@ final class RelauncherUI {
         return footer;
     }
 
+    private static void styleScrollBar(JScrollBar scrollBar, Color trackBackground) {
+        scrollBar.setBackground(trackBackground);
+        scrollBar.setUI(new DarkScrollBarUI());
+        scrollBar.setBackground(trackBackground);
+        scrollBar.setOpaque(true);
+        scrollBar.setBorder(null);
+
+        Dimension preferred = scrollBar.getPreferredSize();
+
+        if (scrollBar.getOrientation() == Adjustable.VERTICAL) {
+            scrollBar.setPreferredSize(new Dimension(scaled(10), preferred.height));
+        } else {
+            scrollBar.setPreferredSize(new Dimension(preferred.width, scaled(10)));
+        }
+    }
+
     static void styleTree(Component component) {
         if (component.getFont() == null) {
             component.setFont(BASE_FONT);
@@ -1098,23 +1114,19 @@ final class RelauncherUI {
             text.setMaximumSize(new Dimension(Integer.MAX_VALUE, fieldHeight));
         } else if (component instanceof JComboBox) {
             JComboBox<?> comboBox = (JComboBox<?>) component;
-            comboBox.setUI(new DarkComboBoxUI());
             comboBox.setOpaque(false);
             comboBox.setBackground(CONTROL);
             comboBox.setForeground(TEXT);
+            installDarkRenderer(comboBox);
+            comboBox.setUI(new DarkComboBoxUI());
             comboBox.setBorder(new RoundedBorder(BORDER, 8));
             int comboHeight = scaled(36);
             comboBox.setPreferredSize(new Dimension(comboBox.getPreferredSize().width, comboHeight));
             comboBox.setMinimumSize(new Dimension(scaled(80), comboHeight));
             comboBox.setMaximumSize(new Dimension(Integer.MAX_VALUE, comboHeight));
-            installDarkRenderer(comboBox);
         } else if (component instanceof JScrollBar) {
             JScrollBar scrollBar = (JScrollBar) component;
-            scrollBar.setUI(new DarkScrollBarUI());
-            scrollBar.setBackground(BACKGROUND);
-            if (scrollBar.getOrientation() == Adjustable.VERTICAL) {
-                scrollBar.setPreferredSize(new Dimension(10, scrollBar.getPreferredSize().height));
-            }
+            styleScrollBar(scrollBar, BACKGROUND);
         } else if (component instanceof JProgressBar) {
             JProgressBar progressBar = (JProgressBar) component;
             progressBar.setUI(new ModernProgressBarUI());
@@ -1862,6 +1874,8 @@ final class RelauncherUI {
 
         private final JComboBox comboBox;
         private final JList list;
+        private final JScrollPane scroller;
+        private final JScrollBar verticalScrollBar;
         private final JPanel popupPanel;
 
         private final MouseListener invocationMouseListener;
@@ -1883,18 +1897,6 @@ final class RelauncherUI {
             list.setCellRenderer(comboBox.getRenderer());
             list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
             list.setFocusable(false);
-            list.setBackground(comboBox.getBackground());
-            list.setForeground(comboBox.getForeground());
-
-            Color selectionBackground = UIManager.getColor("ComboBox.selectionBackground");
-            Color selectionForeground = UIManager.getColor("ComboBox.selectionForeground");
-
-            if (selectionBackground != null) {
-                list.setSelectionBackground(selectionBackground);
-            }
-            if (selectionForeground != null) {
-                list.setSelectionForeground(selectionForeground);
-            }
 
             list.addMouseListener(new MouseAdapter() {
                 @Override
@@ -1920,7 +1922,7 @@ final class RelauncherUI {
                 }
             });
 
-            JScrollPane scroller = new JScrollPane(
+            scroller = new JScrollPane(
                     list,
                     ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
                     ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
@@ -1929,11 +1931,17 @@ final class RelauncherUI {
             scroller.setWheelScrollingEnabled(true);
             scroller.addMouseWheelListener(InputEvent::consume);
 
+            verticalScrollBar = scroller.getVerticalScrollBar();
+
             popupPanel = new JPanel(new BorderLayout());
             popupPanel.setOpaque(true);
             popupPanel.setBackground(comboBox.getBackground());
-            popupPanel.setBorder(UIManager.getBorder("PopupMenu.border"));
+            popupPanel.setBorder(BorderFactory.createCompoundBorder(new RoundedBorder(BORDER, 8),
+                    BorderFactory.createEmptyBorder(1, 1, 1, 1)));
+            popupPanel.putClientProperty(KEEP_OPAQUE, Boolean.TRUE);
             popupPanel.add(scroller, BorderLayout.CENTER);
+
+            applyTheme();
 
             invocationMouseListener = new MouseAdapter() {
                 @Override
@@ -2020,6 +2028,32 @@ final class RelauncherUI {
             comboBox.addPropertyChangeListener(propertyChangeListener);
         }
 
+        private void applyTheme() {
+            list.setOpaque(true);
+            list.setBackground(CONTROL);
+            list.setForeground(TEXT);
+            list.setSelectionBackground(PRIMARY);
+            list.setSelectionForeground(Color.WHITE);
+
+            scroller.setOpaque(true);
+            scroller.setBackground(CONTROL);
+            scroller.setBorder(null);
+
+            JViewport viewport = scroller.getViewport();
+            viewport.setOpaque(true);
+            viewport.setBackground(CONTROL);
+
+            styleScrollBar(verticalScrollBar, CONTROL);
+            verticalScrollBar.setUnitIncrement(18);
+
+            popupPanel.setOpaque(true);
+            popupPanel.setBackground(CONTROL);
+            popupPanel.setBorder(BorderFactory.createCompoundBorder(new RoundedBorder(BORDER, 8),
+                            BorderFactory.createEmptyBorder(1, 1, 1, 1)));
+            popupPanel.revalidate();
+            popupPanel.repaint();
+        }
+
         @Override
         public void show() {
             if (isVisible() || !comboBox.isShowing()) {
@@ -2103,6 +2137,7 @@ final class RelauncherUI {
             list.setFont(comboBox.getFont());
             list.setComponentOrientation(comboBox.getComponentOrientation());
             list.setSelectedIndex(comboBox.getSelectedIndex());
+            applyTheme();
             int rows = Math.max(1, Math.min(comboBox.getMaximumRowCount(), comboBox.getItemCount()));
             list.setVisibleRowCount(rows);
             if (list.getSelectedIndex() >= 0) {
@@ -2275,10 +2310,22 @@ final class RelauncherUI {
 
         @Override
         protected void configureScrollBarColors() {
-            trackColor = BACKGROUND;
+            trackColor = scrollbar != null ? scrollbar.getBackground() : BACKGROUND;
             thumbColor = BORDER;
             thumbHighlightColor = CONTROL_HOVER;
             thumbDarkShadowColor = BORDER;
+            thumbLightShadowColor = BORDER;
+        }
+
+        @Override
+        protected void paintTrack(Graphics graphics, JComponent component, Rectangle bounds) {
+            graphics.setColor(component.getBackground());
+            graphics.fillRect(
+                    bounds.x,
+                    bounds.y,
+                    bounds.width,
+                    bounds.height
+            );
         }
 
         @Override

--- a/src/main/java/com/cleanroommc/relauncher/gui/RelauncherUI.java
+++ b/src/main/java/com/cleanroommc/relauncher/gui/RelauncherUI.java
@@ -10,19 +10,14 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.event.ChangeListener;
 import javax.swing.plaf.basic.*;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ComponentAdapter;
-import java.awt.event.ComponentEvent;
-import java.awt.event.FocusAdapter;
-import java.awt.event.FocusEvent;
-import java.awt.event.KeyEvent;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
+import java.awt.event.*;
 import java.awt.font.TextAttribute;
 import java.awt.geom.Area;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.RoundRectangle2D;
 import java.awt.image.BufferedImage;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
@@ -1614,7 +1609,345 @@ final class RelauncherUI {
 
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static final class LayeredComboPopup implements ComboPopup {
+
+        private final JComboBox comboBox;
+        private final JList list;
+        private final JPanel popupPanel;
+
+        private final MouseListener invocationMouseListener;
+        private final KeyListener keyListener;
+        private final AWTEventListener outsideMouseListener;
+        private final WindowFocusListener windowFocusListener;
+        private final PropertyChangeListener propertyChangeListener;
+
+        private JLayeredPane layeredPane;
+        private Window ownerWindow;
+
+        private boolean armed;
+        private boolean hooksInstalled;
+
+        private LayeredComboPopup(JComboBox comboBox) {
+            this.comboBox = comboBox;
+
+            list = new JList(comboBox.getModel());
+            list.setCellRenderer(comboBox.getRenderer());
+            list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+            list.setFocusable(false);
+            list.setBackground(comboBox.getBackground());
+            list.setForeground(comboBox.getForeground());
+
+            Color selectionBackground = UIManager.getColor("ComboBox.selectionBackground");
+            Color selectionForeground = UIManager.getColor("ComboBox.selectionForeground");
+
+            if (selectionBackground != null) {
+                list.setSelectionBackground(selectionBackground);
+            }
+            if (selectionForeground != null) {
+                list.setSelectionForeground(selectionForeground);
+            }
+
+            list.addMouseListener(new MouseAdapter() {
+                @Override
+                public void mouseReleased(MouseEvent event) {
+                    if (!SwingUtilities.isLeftMouseButton(event)) {
+                        return;
+                    }
+
+                    int index = list.locationToIndex(event.getPoint());
+                    if (index < 0) {
+                        return;
+                    }
+
+                    Rectangle cell = list.getCellBounds(index, index);
+                    if (cell == null || !cell.contains(event.getPoint())) {
+                        return;
+                    }
+
+                    comboBox.setSelectedIndex(index);
+                    hide();
+
+                    event.consume();
+                }
+            });
+
+            JScrollPane scroller = new JScrollPane(
+                    list,
+                    ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
+                    ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+
+            scroller.setFocusable(false);
+            scroller.setWheelScrollingEnabled(true);
+            scroller.addMouseWheelListener(InputEvent::consume);
+
+            popupPanel = new JPanel(new BorderLayout());
+            popupPanel.setOpaque(true);
+            popupPanel.setBackground(comboBox.getBackground());
+            popupPanel.setBorder(UIManager.getBorder("PopupMenu.border"));
+            popupPanel.add(scroller, BorderLayout.CENTER);
+
+            invocationMouseListener = new MouseAdapter() {
+                @Override
+                public void mousePressed(MouseEvent event) {
+                    Component source = (Component) event.getSource();
+                    armed = SwingUtilities.isLeftMouseButton(event) && comboBox.isEnabled() && source.contains(event.getPoint());
+                    if (armed && comboBox.isRequestFocusEnabled()) {
+                        comboBox.requestFocusInWindow();
+                    }
+                }
+
+                @Override
+                public void mouseReleased(MouseEvent event) {
+                    Component source = (Component) event.getSource();
+                    boolean shouldToggle = armed && source.contains(event.getPoint());
+                    armed = false;
+                    if (!shouldToggle) {
+                        return;
+                    }
+
+                    event.consume();
+
+                    SwingUtilities.invokeLater(() -> {
+                        if (!comboBox.isShowing() || !comboBox.isEnabled()) {
+                            return;
+                        }
+                        if (isVisible()) {
+                            hide();
+                        } else {
+                            show();
+                        }
+                    });
+                }
+            };
+
+            keyListener = new KeyAdapter() {
+                @Override
+                public void keyPressed(KeyEvent event) {
+                    if (event.getKeyCode() == KeyEvent.VK_ESCAPE && isVisible()) {
+                        hide();
+                        event.consume();
+                    }
+                }
+            };
+
+            outsideMouseListener = awtEvent -> {
+                if (!isVisible() || !(awtEvent instanceof MouseEvent)) {
+                    return;
+                }
+
+                MouseEvent event = (MouseEvent) awtEvent;
+                if (event.getID() != MouseEvent.MOUSE_PRESSED) {
+                    return;
+                }
+
+                Component source = (Component) event.getSource();
+                if (inside(source, popupPanel) || inside(source, comboBox)) {
+                    return;
+                }
+
+                hide();
+            };
+
+            windowFocusListener = new WindowAdapter() {
+                @Override
+                public void windowLostFocus(WindowEvent event) {
+                    hide();
+                }
+            };
+
+            propertyChangeListener = event -> {
+                String name = event.getPropertyName();
+                if ("model".equals(name)) {
+                    list.setModel((ListModel) event.getNewValue());
+                } else if ("renderer".equals(name)) {
+                    list.setCellRenderer((ListCellRenderer) event.getNewValue());
+                } else if ("font".equals(name)) {
+                    list.setFont((Font) event.getNewValue());
+                } else if ("enabled".equals(name) && !comboBox.isEnabled()) {
+                    hide();
+                }
+            };
+
+            comboBox.addPropertyChangeListener(propertyChangeListener);
+        }
+
+        @Override
+        public void show() {
+            if (isVisible() || !comboBox.isShowing()) {
+                return;
+            }
+
+            JRootPane rootPane = SwingUtilities.getRootPane(comboBox);
+            if (rootPane == null) {
+                return;
+            }
+
+            comboBox.firePopupMenuWillBecomeVisible();
+            syncFromComboBox();
+
+            layeredPane = rootPane.getLayeredPane();
+            layeredPane.add(popupPanel, JLayeredPane.POPUP_LAYER);
+
+            positionPopup();
+
+            popupPanel.setVisible(true);
+            popupPanel.revalidate();
+            popupPanel.repaint();
+
+            installHooks();
+        }
+
+        @Override
+        public void hide() {
+            boolean wasVisible = isVisible();
+
+            uninstallHooks();
+
+            Container parent = popupPanel.getParent();
+            if (parent != null) {
+                parent.remove(popupPanel);
+                parent.revalidate();
+                parent.repaint();
+            }
+
+            layeredPane = null;
+
+            if (wasVisible) {
+                comboBox.firePopupMenuWillBecomeInvisible();
+            }
+        }
+
+        @Override
+        public boolean isVisible() {
+            return popupPanel.getParent() != null;
+        }
+
+        @Override
+        public JList getList() {
+            return list;
+        }
+
+        @Override
+        public MouseListener getMouseListener() {
+            return invocationMouseListener;
+        }
+
+        @Override
+        public MouseMotionListener getMouseMotionListener() {
+            return null;
+        }
+
+        @Override
+        public KeyListener getKeyListener() {
+            return keyListener;
+        }
+
+        @Override
+        public void uninstallingUI() {
+            comboBox.removePropertyChangeListener(propertyChangeListener);
+            hide();
+        }
+
+        private void syncFromComboBox() {
+            list.setModel(comboBox.getModel());
+            list.setCellRenderer(comboBox.getRenderer());
+            list.setFont(comboBox.getFont());
+            list.setComponentOrientation(comboBox.getComponentOrientation());
+            list.setSelectedIndex(comboBox.getSelectedIndex());
+            int rows = Math.max(1, Math.min(comboBox.getMaximumRowCount(), comboBox.getItemCount()));
+            list.setVisibleRowCount(rows);
+            if (list.getSelectedIndex() >= 0) {
+                list.ensureIndexIsVisible(list.getSelectedIndex());
+            }
+        }
+
+        private void positionPopup() {
+            Dimension preferred = popupPanel.getPreferredSize();
+            int width = Math.max(comboBox.getWidth(), preferred.width);
+            int height = preferred.height;
+            width = Math.min(width, layeredPane.getWidth());
+            height = Math.min(height, layeredPane.getHeight());
+
+            Point below = SwingUtilities.convertPoint(
+                    comboBox,
+                    0,
+                    comboBox.getHeight(),
+                    layeredPane);
+            Point top = SwingUtilities.convertPoint(
+                    comboBox,
+                    0,
+                    0,
+                    layeredPane);
+
+            int x = Math.max(0, Math.min(below.x, layeredPane.getWidth() - width));
+            int y = below.y;
+
+            if (y + height > layeredPane.getHeight() && top.y - height >= 0) {
+                y = top.y - height;
+            } else {
+                y = Math.max(0, Math.min(y, layeredPane.getHeight() - height));
+            }
+
+            popupPanel.setBounds(
+                    x,
+                    y,
+                    width,
+                    height);
+        }
+
+        private void installHooks() {
+            if (hooksInstalled) {
+                return;
+            }
+
+            hooksInstalled = true;
+
+            Toolkit.getDefaultToolkit().addAWTEventListener(outsideMouseListener, AWTEvent.MOUSE_EVENT_MASK);
+
+            ownerWindow = SwingUtilities.getWindowAncestor(comboBox);
+
+            if (ownerWindow != null) {
+                ownerWindow.addWindowFocusListener(windowFocusListener);
+            }
+        }
+
+        private void uninstallHooks() {
+            if (!hooksInstalled) {
+                return;
+            }
+
+            hooksInstalled = false;
+
+            Toolkit.getDefaultToolkit().removeAWTEventListener(outsideMouseListener);
+
+            if (ownerWindow != null) {
+                ownerWindow.removeWindowFocusListener(windowFocusListener);
+                ownerWindow = null;
+            }
+        }
+
+        private static boolean inside(Component child, Component ancestor) {
+            return child == ancestor || SwingUtilities.isDescendingFrom(child, ancestor);
+        }
+    }
+
     private static final class DarkComboBoxUI extends BasicComboBoxUI {
+
+        @Override
+        protected FocusListener createFocusListener() {
+            return new FocusAdapter() {
+                @Override
+                public void focusGained(FocusEvent event) {
+                    comboBox.repaint();
+                }
+
+                @Override
+                public void focusLost(FocusEvent event) {
+                    comboBox.repaint();
+                }
+            };
+        }
 
         @Override
         protected JButton createArrowButton() {
@@ -1661,18 +1994,7 @@ final class RelauncherUI {
 
         @Override
         protected ComboPopup createPopup() {
-            return new BasicComboPopup(comboBox) {
-                @Override
-                protected JScrollPane createScroller() {
-                    JScrollPane scroller = super.createScroller();
-                    scroller.setBorder(new RoundedBorder(BORDER, 8));
-                    scroller.getViewport().setBackground(CONTROL);
-                    JScrollBar bar = scroller.getVerticalScrollBar();
-                    bar.setUI(new DarkScrollBarUI());
-                    bar.setPreferredSize(new Dimension(10, bar.getPreferredSize().height));
-                    return scroller;
-                }
-            };
+            return new LayeredComboPopup(comboBox);
         }
 
     }

--- a/src/main/java/com/cleanroommc/relauncher/gui/RelauncherUI.java
+++ b/src/main/java/com/cleanroommc/relauncher/gui/RelauncherUI.java
@@ -1932,6 +1932,7 @@ final class RelauncherUI {
             scroller.addMouseWheelListener(InputEvent::consume);
 
             verticalScrollBar = scroller.getVerticalScrollBar();
+            verticalScrollBar.setUnitIncrement(scaled(10));
 
             popupPanel = new JPanel(new BorderLayout());
             popupPanel.setOpaque(true);
@@ -2044,7 +2045,7 @@ final class RelauncherUI {
             viewport.setBackground(CONTROL);
 
             styleScrollBar(verticalScrollBar, CONTROL);
-            verticalScrollBar.setUnitIncrement(18);
+            verticalScrollBar.setUnitIncrement(scaled(10));
 
             popupPanel.setOpaque(true);
             popupPanel.setBackground(CONTROL);

--- a/src/main/java/com/cleanroommc/relauncher/gui/RelauncherUI.java
+++ b/src/main/java/com/cleanroommc/relauncher/gui/RelauncherUI.java
@@ -1033,7 +1033,9 @@ final class RelauncherUI {
             JComponent swing = (JComponent) component;
             swing.putClientProperty(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
             swing.putClientProperty(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_OFF);
-            LayeredToolTipSupport.install((JComponent) component);
+            if (swing.getToolTipText() != null) {
+                LayeredToolTipSupport.install(swing);
+            }
         }
 
         if (component instanceof JCheckBox) {

--- a/src/main/java/com/cleanroommc/relauncher/gui/RelauncherUI.java
+++ b/src/main/java/com/cleanroommc/relauncher/gui/RelauncherUI.java
@@ -16,7 +16,6 @@ import java.awt.geom.Area;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.RoundRectangle2D;
 import java.awt.image.BufferedImage;
-import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
@@ -777,6 +776,11 @@ final class RelauncherUI {
         return row;
     }
 
+    static void tooltip(JComponent component, String text) {
+        component.setToolTipText(text);
+        LayeredToolTipSupport.install(component);
+    }
+
     /** Handle for a two-option segmented control, {@link #panel} is the component to add. */
     static final class SegmentedControl {
 
@@ -1029,6 +1033,7 @@ final class RelauncherUI {
             JComponent swing = (JComponent) component;
             swing.putClientProperty(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
             swing.putClientProperty(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_OFF);
+            LayeredToolTipSupport.install((JComponent) component);
         }
 
         if (component instanceof JCheckBox) {
@@ -1505,7 +1510,7 @@ final class RelauncherUI {
 
         private void updateDescription() {
             String description = isSelected() ? "Dark mode. Switch to light mode." : "Light mode. Switch to dark mode.";
-            setToolTipText(description);
+            tooltip(this, description);
             getAccessibleContext().setAccessibleDescription(description);
         }
 
@@ -1607,6 +1612,247 @@ final class RelauncherUI {
             g.dispose();
         }
 
+    }
+
+    private static final class LayeredToolTipSupport extends MouseAdapter {
+
+        private static final String INSTALLED = "relauncher.layeredToolTipInstalled";
+        private static final LayeredToolTipSupport INSTANCE = new LayeredToolTipSupport();
+
+        private static final int CURSOR_OFFSET_X = 12;
+        private static final int CURSOR_OFFSET_Y = 20;
+        private static final int FLIPPED_OFFSET_Y = 8;
+
+        private final Timer showTimer;
+        private final Timer dismissTimer;
+
+        private JComponent owner;
+        private Point ownerPoint;
+        private String text;
+
+        private JToolTip tip;
+        private JLayeredPane layeredPane;
+        private Window ownerWindow;
+
+        private final WindowAdapter windowListener = new WindowAdapter() {
+            @Override
+            public void windowLostFocus(WindowEvent event) {
+                hide();
+            }
+
+            @Override
+            public void windowClosed(WindowEvent event) {
+                hide();
+            }
+        };
+
+        private LayeredToolTipSupport() {
+            showTimer = new Timer(750, event -> showNow());
+            showTimer.setRepeats(false);
+
+            dismissTimer = new Timer(4000, event -> hide());
+            dismissTimer.setRepeats(false);
+        }
+
+        static void install(JComponent component) {
+            ToolTipManager.sharedInstance().unregisterComponent(component);
+
+            if (Boolean.TRUE.equals(component.getClientProperty(INSTALLED))) {
+                return;
+            }
+
+            component.putClientProperty(INSTALLED, Boolean.TRUE);
+
+            component.addMouseListener(INSTANCE);
+            component.addMouseMotionListener(INSTANCE);
+            component.addMouseWheelListener(INSTANCE);
+        }
+
+        @Override
+        public void mouseEntered(MouseEvent event) {
+            updateTarget(event);
+        }
+
+        @Override
+        public void mouseMoved(MouseEvent event) {
+            updateTarget(event);
+        }
+
+        @Override
+        public void mouseExited(MouseEvent event) {
+            if (event.getSource() == owner) {
+                hide();
+            }
+        }
+
+        @Override
+        public void mousePressed(MouseEvent event) {
+            hide();
+        }
+
+        @Override
+        public void mouseDragged(MouseEvent event) {
+            hide();
+        }
+
+        @Override
+        public void mouseWheelMoved(MouseWheelEvent event) {
+            hide();
+        }
+
+        private void updateTarget(MouseEvent event) {
+            if (!(event.getSource() instanceof JComponent)) {
+                hide();
+                return;
+            }
+
+            JComponent nextOwner = (JComponent) event.getSource();
+
+            if (!nextOwner.isEnabled() || !nextOwner.isShowing()) {
+                hide();
+                return;
+            }
+
+            String nextText = nextOwner.getToolTipText(event);
+
+            if (nextText == null || nextText.isEmpty()) {
+                if (nextOwner == owner) {
+                    hide();
+                }
+                return;
+            }
+
+            Point nextPoint = event.getPoint();
+
+            if (tip != null && nextOwner == owner) {
+                ownerPoint = nextPoint;
+                text = nextText;
+
+                tip.setTipText(text);
+                positionTip();
+
+                dismissTimer.restart();
+                return;
+            }
+
+            if (nextOwner != owner) {
+                hide();
+            }
+
+            owner = nextOwner;
+            ownerPoint = nextPoint;
+            text = nextText;
+
+            showTimer.restart();
+        }
+
+        private void showNow() {
+            if (owner == null || ownerPoint == null || text == null || !owner.isShowing()) {
+                hide();
+                return;
+            }
+
+            JRootPane rootPane = SwingUtilities.getRootPane(owner);
+
+            if (rootPane == null) {
+                hide();
+                return;
+            }
+
+            removeTipComponent();
+
+            layeredPane = rootPane.getLayeredPane();
+
+            tip = owner.createToolTip();
+            tip.setTipText(text);
+
+            tip.putClientProperty(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
+            tip.putClientProperty(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_OFF);
+
+            layeredPane.add(tip, Integer.valueOf(JLayeredPane.POPUP_LAYER + 1));
+
+            positionTip();
+
+            tip.setVisible(true);
+            tip.revalidate();
+            tip.repaint();
+
+            ownerWindow = SwingUtilities.getWindowAncestor(owner);
+
+            if (ownerWindow != null) {
+                ownerWindow.addWindowFocusListener(windowListener);
+            }
+
+            dismissTimer.restart();
+        }
+
+        private void positionTip() {
+            if (tip == null || layeredPane == null || owner == null || ownerPoint == null) {
+                return;
+            }
+
+            Point cursor = SwingUtilities.convertPoint(owner, ownerPoint, layeredPane);
+
+            Dimension size = tip.getPreferredSize();
+
+            int x = cursor.x + CURSOR_OFFSET_X;
+            int y = cursor.y + CURSOR_OFFSET_Y;
+
+            if (y + size.height > layeredPane.getHeight()) {
+                y = cursor.y - size.height - FLIPPED_OFFSET_Y;
+            }
+
+            int maxX = Math.max(0, layeredPane.getWidth() - size.width);
+            int maxY = Math.max(0, layeredPane.getHeight() - size.height);
+
+            x = Math.max(0, Math.min(x, maxX));
+            y = Math.max(0, Math.min(y, maxY));
+
+            tip.setBounds(
+                    x,
+                    y,
+                    size.width,
+                    size.height
+            );
+        }
+
+        private void hide() {
+            showTimer.stop();
+            dismissTimer.stop();
+
+            removeTipComponent();
+
+            owner = null;
+            ownerPoint = null;
+            text = null;
+        }
+
+        private void removeTipComponent() {
+            if (ownerWindow != null) {
+                ownerWindow.removeWindowFocusListener(windowListener);
+                ownerWindow = null;
+            }
+
+            if (tip != null) {
+                Container parent = tip.getParent();
+                if (parent != null) {
+                    Rectangle dirty = tip.getBounds();
+
+                    parent.remove(tip);
+                    parent.revalidate();
+                    parent.repaint(
+                            dirty.x,
+                            dirty.y,
+                            dirty.width,
+                            dirty.height
+                    );
+                }
+
+                tip = null;
+            }
+
+            layeredPane = null;
+        }
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})


### PR DESCRIPTION
Fixes:
- Set `resizable` to false so the window is guaranteed to be floating on Niri
- Implement `LayeredToolTipSupport` and `LayeredComboPopup` to replace the default Java8 Swing behavior which causes artifacts in certain environments
- The new combo-box menu and tooltip are identical to the old ones visually, but rendered as in-window overlays and clamped to the host window's bounds

This PR is tested on Niri (Wayland), Gnome (Wayland), Win 10

_Niri_
<img width="786" height="858" alt="Screenshot from 2026-08-01 14-13-32" src="https://github.com/user-attachments/assets/fabffa1f-0df5-4ece-acfd-3d1d52200b6b" />

_Gnome_
<img width="790" height="976" alt="2026-08-01_14-14" src="https://github.com/user-attachments/assets/1a59df48-4164-432d-af0a-81625210a159" />

_Win 10_
<img width="777" height="874" alt="Snipaste_2026-08-01_16-33-46" src="https://github.com/user-attachments/assets/d7277a45-5e0b-4661-a84d-2e91458e5149" />
